### PR TITLE
William/simpler errors

### DIFF
--- a/test/locateError.test.js
+++ b/test/locateError.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { asArray, asMap, asNumber, asObject } from '../src/index.js'
+import { asArray, asJSON, asMap, asNumber, asObject } from '../src/index.js'
 
 describe('locateError', function () {
   it('makes nicely nested errors', function () {
@@ -36,6 +36,16 @@ describe('locateError', function () {
       expect(error).not.instanceOf(Error)
       expect(error.message).equals('boom')
       expect(typeof error.addStep).equals('undefined')
+    }
+  })
+
+  it('works with JSON errors', function () {
+    const asNested = asObject({ json: asJSON(asArray(asNumber)) })
+    try {
+      asNested({ json: '[false]' })
+      throw new Error('Expecting an error')
+    } catch (error) {
+      expect(error.message).equals('Expected a number at JSON.parse(.json)[0]')
     }
   })
 })

--- a/test/locateError.test.js
+++ b/test/locateError.test.js
@@ -16,7 +16,7 @@ describe('locateError', function () {
       expect(error.message).equals(
         'Expected a number at .map["odd \\"item\\""][0]'
       )
-      expect(typeof error.addStep).equals('function')
+      expect(typeof error.insertStepAt).equals('number')
     }
   })
 
@@ -35,7 +35,7 @@ describe('locateError', function () {
     } catch (error) {
       expect(error).not.instanceOf(Error)
       expect(error.message).equals('boom')
-      expect(typeof error.addStep).equals('undefined')
+      expect(typeof error.insertStepAt).equals('undefined')
     }
   })
 


### PR DESCRIPTION
This means that the cleaner errors will no longer crash as they pass through yaob.

I would like to find a better name for `nextStep`. Maybe `insertStepAt`?