### PR TITLE
Uncleaning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,21 +80,3 @@ type Message = ReturnType<typeof asMessage>
 // Flow:
 type Message = $Call<typeof asMessage>
 ```
-
-## Installing Cleaners
-
-If you are using Deno, just import cleaners directly:
-
-```js
-import { asString } from 'https://deno.land/x/cleaners/mod.ts'
-```
-
-If you are using Node, first install the package using `npm i cleaners` or `yarn add cleaners`, and then import it using either syntax:
-
-```js
-// The oldschool way:
-const { asString } = require('cleaners')
-
-// Or using Node's new native module support:
-import { asString } from 'cleaners'
-```

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,3 +80,13 @@ type Message = ReturnType<typeof asMessage>
 // Flow:
 type Message = $Call<typeof asMessage>
 ```
+
+## Converting Data
+
+Since JSON doesn't have its own date type, people usually send dates as strings:
+
+```js
+{ "birthday": "2010-04-01" }
+```
+
+It's not enough to check that `birthday` is a string - the contents need to be parsed and validated as well. Fortunately, cleaners can do this. The `asDate` cleaner will actually parse strings into Javascript date objects, solving this problem.

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ async function getMessage(id: string) {
 }
 ```
 
-If the server sends bad data, this example will simply throw an exception rather than return data in the wrong format. Even if the server sends malicious properties like `__proto__`, this example will simply filter those out.
+If the server sends bad data, this example will simply throw an exception rather than return data in the wrong format. Even if the server sends malicious properties like `__proto__`, the cleaner will simply filter those out.
 
 ## Automatic Type Definitions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,3 +90,28 @@ Since JSON doesn't have its own date type, people usually send dates as strings:
 ```
 
 It's not enough to check that `birthday` is a string - the contents need to be parsed and validated as well. Fortunately, cleaners can do this. The `asDate` cleaner will actually parse strings into Javascript date objects, solving this problem.
+
+## Uncleaning
+
+When cleaners do additional data conversions, such as parsing strings into dates, it is useful to be able to undo those conversions. For instance, if a cleaner parses data from disk, those changes need to be undone before writing the file back to disk.
+
+To handle cases like this, use the `uncleaner` function:
+
+```js
+const asFile = asJSON(asObject({ lastLogin: asDate }))
+const wasFile = uncleaner(asFile)
+```
+
+The `wasFile` function will undo the conversions performed in the `asFile` cleaner. In this example, it will convert the date back into a string, and then encode everything back into JSON.
+
+```js
+// Read & parse the file:
+const file = asFile(fs.readFileSync('lastLogin.json', 'utf8'))
+
+// Make changes:
+console.log(file.lastLogin)
+file.lastLogin = new Date()
+
+// Re-encode and write the file:
+fs.writeFileSync('lastLogin.json', wasFile(file))
+```

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -18,16 +18,6 @@ const { asString } = require('cleaners')
 import { asString } from 'cleaners'
 ```
 
-## Converting Data
-
-Since JSON doesn't have its own date type, people usually send dates as strings:
-
-```js
-{ "birthday": "2010-04-01" }
-```
-
-It's not enough to check that `birthday` is a string - the contents need to be parsed and validated as well. Fortunately, cleaners can do this. The `asDate` cleaner will actually parse strings into Javascript date objects, solving this problem.
-
 ## Writing Custom Cleaners
 
 Since cleaners are just functions, you can easily create your own as well, which is useful if you need extra data validation:

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -31,16 +31,21 @@ function asEvenNumber(raw: any): number {
 }
 ```
 
-Or extra data conversions:
+You can pass this function to `asObject` or any of the others helpers, and they will work perfectly, including TypeScript & Flow return-type inference.
+
+If your clenaer performs data conversions, wrap it in the `asCodec` helper:
 
 ```js
 import { asString, Cleaner } from 'cleaners'
 import { base64 } from 'rfc4648'
 
-const asBase64Data: Cleaner<Uint8Array> = raw => base64.parse(asString(raw))
+const asBase64: Cleaner<Uint8Array> = asCodec(
+  raw => base64.parse(asString(raw))
+  clean => base64.stringify(clean)
+)
 ```
 
-You can pass these functions to `asObject` or any of the others helpers, and they will work perfectly, including TypeScript & Flow return-type inference.
+The first parameter to `asCodec` is the cleaner, and the second parameter is the un-cleaner.
 
 ## Recursive Cleaners
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,5 +1,23 @@
 # Guides
 
+## Installing Cleaners
+
+If you are using Deno, just import cleaners directly:
+
+```js
+import { asString } from 'https://deno.land/x/cleaners/mod.ts'
+```
+
+If you are using Node, first install the package using `npm i cleaners` or `yarn add cleaners`, and then import it using either syntax:
+
+```js
+// The oldschool way:
+const { asString } = require('cleaners')
+
+// Or using Node's new native module support:
+import { asString } from 'cleaners'
+```
+
 ## Converting Data
 
 Since JSON doesn't have its own date type, people usually send dates as strings:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,22 +10,25 @@ Primitive values:
 - `asUndefined` - Accepts & returns `undefined`.
 - `asUnknown` - Accepts anything.
 
-Arrays and objects:
+Data structures:
 
-- `asArray` - Builds an array cleaner.
-- `asObject` - Builds an object cleaner.
-- `asMap` - Deprecated alias for `asObject`.
+- [`asArray`](#asArray) - Builds an array cleaner.
+- [`asObject`](#asObject) - Builds an object cleaner.
 
-Missing data:
+Branching:
 
-- `asEither` - Builds a cleaner for an item that might have multiple types.
-- `asMaybe` - Builds a cleaner that quietly ignores invalid data.
-- `asOptional` - Builds a cleaner for an item that might be undefined or null.
+- [`asEither`](#asEither) - Builds a cleaner for an item that might have multiple types.
+- [`asMaybe`](#asMaybe) - Builds a cleaner that quietly ignores invalid data.
+- [`asOptional`](#asOptional) - Builds a cleaner for an item that might be undefined or null.
 
-String parsing:
+Parsing:
 
 - `asDate` - Accepts & returns a `Date`, but parses strings if needed.
-- `asJSON` - Builds a cleaner for JSON strings.
+- [`asJSON`](#asJSON) - Builds a cleaner for JSON strings.
+
+Deprecated:
+
+- `asMap` - Renamed to [`asObject`](#asObject).
 
 ## asArray
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -23,8 +23,10 @@ Branching:
 
 Parsing:
 
+- [`asCodec`](#asCodec) - Builds a cleaner that can undo its own data conversion.
 - `asDate` - Accepts & returns a `Date`, but parses strings if needed.
 - [`asJSON`](#asJSON) - Builds a cleaner for JSON strings.
+- [`uncleaner`](#uncleaner) - Builds an uncleaner function, which reverses the effect of a cleaner.
 
 Deprecated:
 
@@ -38,6 +40,22 @@ Deprecated:
 // Makes a Cleaner<string[]>:
 const asStringList = asArray(asString)
 ```
+
+## asCodec
+
+`asCodec` creates a cleaner that can undo its own data conversion. This is useful for cleaners that parse strings or similar things.
+
+```js
+// Converts UNIX timestamps to / from  Javascript Date objects:
+const asUnixDate: Cleaner<Date> = asCodec(
+  raw => new Date(1000 * asNumber(raw)),
+  clean => clean.valueOf() / 1000
+)
+```
+
+The first parameter to `asCodec` is the regular cleaner function, which accepts raw data and returns clean data. The second parameter is the un-cleaner function, which turns the clean data (a `Date` in the example above) back into raw data (a UNIX timestamp in this case).
+
+To get access to the un-cleaner, see `uncleaner`.
 
 ## asEither
 
@@ -163,3 +181,16 @@ const asMaximum = asOptional(asNumber)
 
 asMaximum(null) // returns undefined
 ```
+
+## uncleaner
+
+The `uncleaner` turns a cleaner into an un-cleaner.
+
+```js
+const asThing: Cleaner<T> = ...
+const wasThing: Uncleaner<T> = uncleaner(asThing)
+```
+
+This un-cleaner will un-do any data conversions (such as string parsing) performed by the cleaner.
+
+Un-cleaners have the oposite data types as their corresponding cleaner. Since all cleaners accept `unknown` and return some known type `T`, the matching un-cleaner will accept type `T` and return `unknown`.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+// type names ----------------------------------------------------------------
+
 /**
  * Reads & checks an untrusted value. Throws an exception if it's wrong.
  */
@@ -18,7 +20,6 @@ export declare interface ObjectCleaner<T> extends Cleaner<T> {
 // simple types --------------------------------------------------------------
 
 export declare const asBoolean: Cleaner<boolean>
-export declare const asDate: Cleaner<Date>
 export declare const asNone: Cleaner<undefined>
 export declare const asNull: Cleaner<null>
 export declare const asNumber: Cleaner<number>
@@ -26,10 +27,23 @@ export declare const asString: Cleaner<string>
 export declare const asUndefined: Cleaner<undefined>
 export declare const asUnknown: Cleaner<unknown>
 
-// nested types ----------------------------------------------------------------
+// data structures -----------------------------------------------------------
 
+/**
+ * Makes a cleaner that accepts an array with the given item type.
+ */
 export declare function asArray<T>(cleaner: Cleaner<T>): Cleaner<T[]>
 
+/**
+ * Makes a cleaner that accepts an object.
+ *
+ * If asObject receives a single cleaner function,
+ * it will will use that to clean all the object's own enumerable properties
+ * (except "__proto__", which gets filtered out).
+ *
+ * Otherwise, if asObject receives an object with cleaners as properties,
+ * it will apply each cleaner to the matching key in the object.
+ */
 export declare function asObject<T>(
   cleaner: Cleaner<T>
 ): Cleaner<{ [keys: string]: T }>
@@ -37,8 +51,27 @@ export declare function asObject<T extends object>(
   shape: ObjectShape<T>
 ): ObjectCleaner<T>
 
-export declare const asMap: typeof asObject
+// branching -----------------------------------------------------------------
 
+/**
+ * Makes a cleaner that accepts either of the given types.
+ */
+export declare function asEither<A, B>(
+  a: Cleaner<A>,
+  b: Cleaner<B>
+): Cleaner<A | B>
+
+/**
+ * Wraps a cleaner with an error handling,
+ * returning a fallback value (or `undefined`) if the cleaner throws.
+ */
+export declare function asMaybe<T>(cleaner: Cleaner<T>): Cleaner<T | undefined>
+export declare function asMaybe<T>(cleaner: Cleaner<T>, fallback: T): Cleaner<T>
+
+/**
+ * Unpacks a value that may be void or null,
+ * returning a fallback value (or `undefined`) if missing.
+ */
 export declare function asOptional<T>(
   cleaner: Cleaner<T>
 ): Cleaner<T | undefined>
@@ -47,12 +80,21 @@ export declare function asOptional<T>(
   fallback: T
 ): Cleaner<T>
 
-export declare function asEither<A, B>(
-  a: Cleaner<A>,
-  b: Cleaner<B>
-): Cleaner<A | B>
+// parsing -------------------------------------------------------------------
 
-export declare function asMaybe<T>(cleaner: Cleaner<T>): Cleaner<T | undefined>
-export declare function asMaybe<T>(cleaner: Cleaner<T>, fallback: T): Cleaner<T>
+/**
+ * Parses a string into a Javascript Date object.
+ */
+export declare const asDate: Cleaner<Date>
 
+/**
+ * Parses a string as JSON, and then cleans the contents.
+ */
 export declare function asJSON<T>(cleaner: Cleaner<T>): Cleaner<T>
+
+// deprecated ----------------------------------------------------------------
+
+/**
+ * Deprecated. Use `asObject` directly.
+ */
+export declare const asMap: typeof asObject

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,11 @@
  */
 export declare type Cleaner<T> = (raw: any) => T
 
+/**
+ * Undoes the effect of a cleaner.
+ */
+export declare type Uncleaner<T> = (clean: T) => unknown
+
 declare type ObjectShape<T> = {
   [K in keyof T]: Cleaner<T[K]>
 }
@@ -83,6 +88,14 @@ export declare function asOptional<T>(
 // parsing -------------------------------------------------------------------
 
 /**
+ * Creates a cleaner that can undo its own data conversions.
+ */
+declare function asCodec<T>(
+  cleaner: Cleaner<T>,
+  uncleaner: Uncleaner<T>
+): Cleaner<T>
+
+/**
  * Parses a string into a Javascript Date object.
  */
 export declare const asDate: Cleaner<Date>
@@ -91,6 +104,11 @@ export declare const asDate: Cleaner<Date>
  * Parses a string as JSON, and then cleans the contents.
  */
 export declare function asJSON<T>(cleaner: Cleaner<T>): Cleaner<T>
+
+/**
+ * Gets the uncleaner that undoes a cleaner's data conversions.
+ */
+export declare function uncleaner<T>(cleaner: Cleaner<T>): Uncleaner<T>
 
 // deprecated ----------------------------------------------------------------
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,25 +30,12 @@ export function asNone(raw) {
   return undefined
 }
 
-export function asDate(raw) {
-  if (typeof raw !== 'string' && !(raw instanceof Date)) {
-    throw new TypeError('Expected a date string')
-  }
-
-  const out = new Date(raw)
-  if (out.toJSON() == null) throw new TypeError('Invalid date format')
-  return out
-}
-
 export function asUnknown(raw) {
   return raw
 }
 
-// nested types ----------------------------------------------------------------
+// data structures -----------------------------------------------------------
 
-/**
- * Makes a cleaner that accepts an array with the given item type.
- */
 export function asArray(cleaner) {
   return function asArray(raw) {
     if (!Array.isArray(raw)) {
@@ -67,16 +54,6 @@ export function asArray(cleaner) {
   }
 }
 
-/**
- * Makes a cleaner that accepts an object.
- *
- * If asObject receives a single cleaner function,
- * it will will use that to clean all the object's own enumerable properties
- * (except "__proto__", which gets filtered out).
- *
- * Otherwise, if asObject receives an object with cleaners as properties,
- * it will apply each cleaner to the matching key in the object.
- */
 export function asObject(shape) {
   // The key-value version:
   if (typeof shape === 'function') {
@@ -135,10 +112,45 @@ export function asObject(shape) {
   return out
 }
 
-/**
- * Deprecated. Use `asObject` directly.
- */
-export const asMap = asObject
+// branching -----------------------------------------------------------------
+
+export function asEither(a, b) {
+  return function asEither(raw) {
+    try {
+      return a(raw)
+    } catch (e) {
+      return b(raw)
+    }
+  }
+}
+
+export function asMaybe(cleaner, fallback) {
+  return function asMaybe(raw) {
+    try {
+      return cleaner(raw)
+    } catch (e) {
+      return fallback
+    }
+  }
+}
+
+export function asOptional(cleaner, fallback) {
+  return function asOptional(raw) {
+    return raw != null ? cleaner(raw) : fallback
+  }
+}
+
+// parsing -------------------------------------------------------------------
+
+export function asDate(raw) {
+  if (typeof raw !== 'string' && !(raw instanceof Date)) {
+    throw new TypeError('Expected a date string')
+  }
+
+  const out = new Date(raw)
+  if (out.toJSON() == null) throw new TypeError('Invalid date format')
+  return out
+}
 
 export function asJSON(cleaner) {
   return function asJSON(raw) {
@@ -151,44 +163,11 @@ export function asJSON(cleaner) {
   }
 }
 
-/**
- * Unpacks a value that may be void or null,
- * returning a fallback value (or `undefined`) if missing.
- */
-export function asOptional(cleaner, fallback) {
-  return function asOptional(raw) {
-    return raw != null ? cleaner(raw) : fallback
-  }
-}
+// deprecated ----------------------------------------------------------------
 
-/**
- * Makes a cleaner that accepts either of the given types.
- */
-export function asEither(a, b) {
-  return function asEither(raw) {
-    try {
-      return a(raw)
-    } catch (e) {
-      return b(raw)
-    }
-  }
-}
+export const asMap = asObject
 
-/**
- * Unpacks a value that may be void or null,
- * returning a fallback value (or `undefined`) if missing.
- */
-export function asMaybe(cleaner, fallback) {
-  return function asMaybe(raw) {
-    try {
-      return cleaner(raw)
-    } catch (e) {
-      return fallback
-    }
-  }
-}
-
-// helpers ---------------------------------------------------------------------
+// helpers -------------------------------------------------------------------
 
 /**
  * Adds location information to an error message.

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,22 +1,19 @@
 // @flow
 
-/**
- * Reads & checks an untrusted value. Throws an exception if it's wrong.
- */
+// type names ----------------------------------------------------------------
+
 export type Cleaner<T> = (raw: any) => T
 
-/**
- * A cleaner, but with some extra properties:
- */
 export type ObjectCleaner<T> = Cleaner<T> & {
   +shape: $ObjMap<T, <T>(type: T) => Cleaner<T>>,
   +withRest: Cleaner<T>
 }
 
+type ReturnType = <T>(f: () => T) => T
+
 // simple types --------------------------------------------------------------
 
 declare export var asBoolean: Cleaner<boolean>
-declare export var asDate: Cleaner<Date>
 declare export var asNone: Cleaner<void>
 declare export var asNull: Cleaner<null>
 declare export var asNumber: Cleaner<number>
@@ -24,9 +21,7 @@ declare export var asString: Cleaner<string>
 declare export var asUndefined: Cleaner<void>
 declare export var asUnknown: Cleaner<mixed>
 
-// nested types ----------------------------------------------------------------
-
-type ReturnType = <T>(f: () => T) => T
+// data structures -----------------------------------------------------------
 
 declare export function asArray<T>(cleaner: Cleaner<T>): Cleaner<T[]>
 
@@ -35,12 +30,7 @@ declare export var asObject: {|
   <Shape>(shape: Shape): ObjectCleaner<$ObjMap<Shape, ReturnType>>
 |}
 
-declare export var asMap: typeof asObject
-
-declare export var asOptional: {|
-  <T>(cleaner: Cleaner<T>): Cleaner<T | void>,
-  <T>(cleaner: Cleaner<T>, fallback: $Call<Cleaner<T>>): Cleaner<T>
-|}
+// branching -----------------------------------------------------------------
 
 declare export function asEither<A, B>(
   a: Cleaner<A>,
@@ -52,4 +42,17 @@ declare export var asMaybe: {|
   <T>(cleaner: Cleaner<T>, fallback: $Call<Cleaner<T>>): Cleaner<T>
 |}
 
+declare export var asOptional: {|
+  <T>(cleaner: Cleaner<T>): Cleaner<T | void>,
+  <T>(cleaner: Cleaner<T>, fallback: $Call<Cleaner<T>>): Cleaner<T>
+|}
+
+// parsing -------------------------------------------------------------------
+
+declare export var asDate: Cleaner<Date>
+
 declare export function asJSON<T>(cleaner: Cleaner<T>): Cleaner<T>
+
+// deprecated ----------------------------------------------------------------
+
+declare export var asMap: typeof asObject

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,6 +4,8 @@
 
 export type Cleaner<T> = (raw: any) => T
 
+export type Uncleaner<T> = (clean: T) => mixed
+
 export type ObjectCleaner<T> = Cleaner<T> & {
   +shape: $ObjMap<T, <T>(type: T) => Cleaner<T>>,
   +withRest: Cleaner<T>
@@ -49,9 +51,16 @@ declare export var asOptional: {|
 
 // parsing -------------------------------------------------------------------
 
+declare export function asCodec<T>(
+  cleaner: Cleaner<T>,
+  uncleaner: Uncleaner<T>
+): Cleaner<T>
+
 declare export var asDate: Cleaner<Date>
 
 declare export function asJSON<T>(cleaner: Cleaner<T>): Cleaner<T>
+
+declare export function uncleaner<T>(cleaner: Cleaner<T>): Uncleaner<T>
 
 // deprecated ----------------------------------------------------------------
 

--- a/test/cleaners/asCodec.test.js
+++ b/test/cleaners/asCodec.test.js
@@ -1,0 +1,18 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { asDate, asJSON, asObject, uncleaner } from '../../src/index.js'
+
+describe('asCodec', function () {
+  const asFile = asJSON(asObject({ lastLogin: asDate }))
+  const wasFile = uncleaner(asFile)
+
+  it('round-trips data', function () {
+    const raw = '{"lastLogin":"2020-02-20T00:00:00.000Z"}'
+
+    const clean = asFile(raw)
+    console.log(clean.lastLogin)
+    expect(clean).deep.equals({ lastLogin: new Date('2020-02-20') })
+    expect(wasFile(clean)).deep.equals(raw)
+  })
+})

--- a/test/flow.js
+++ b/test/flow.js
@@ -4,6 +4,7 @@
 import {
   asArray,
   asBoolean,
+  asCodec,
   asDate,
   asEither,
   asJSON,
@@ -19,9 +20,15 @@ import {
   asUnknown
 } from '../src/index.js'
 
+const asUnixDate = asCodec(
+  raw => new Date(1000 * asNumber(raw)),
+  clean => clean.valueOf() / 1000
+)
+
 type Expected = {
   array: string[],
   date: Date,
+  unixDate: Date,
   either: string | number,
   json: number[],
   map: { [key: string]: number },
@@ -45,6 +52,7 @@ type Expected = {
 const cleaner = asObject({
   array: asArray(asString),
   date: asDate,
+  unixDate: asUnixDate,
   either: asEither(asString, asNumber),
   json: asJSON(asArray(asNumber)),
   map: asMap(asNumber),

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -3,6 +3,7 @@
 import {
   asArray,
   asBoolean,
+  asCodec,
   asDate,
   asEither,
   asJSON,
@@ -18,9 +19,15 @@ import {
   asUnknown
 } from '../src/index.js'
 
+const asUnixDate = asCodec(
+  raw => new Date(1000 * asNumber(raw)),
+  clean => clean.valueOf() / 1000
+)
+
 interface Expected {
   array: string[]
   date: Date
+  unixDate: Date
   either: string | number
   json: number[]
   map: { [key: string]: number }
@@ -44,6 +51,7 @@ interface Expected {
 const cleaner = asObject({
   array: asArray(asString),
   date: asDate,
+  unixDate: asUnixDate,
   either: asEither(asString, asNumber),
   json: asJSON(asArray(asNumber)),
   map: asMap(asNumber),


### PR DESCRIPTION
This adds an `asCodec` and matching `uncleaner` function. Together, these provide a a straightforward way to undo any parsing or data conversion that happens in a cleaner.