### PR TITLE
Fix packaging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
   },
   "plugins": ["simple-import-sort"],
   "rules": {
+    "import/extensions": ["error", "always"],
     "simple-import-sort/imports": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,14 +10,21 @@
   "repository": "https://www.github.com/swansontec/cleaners",
   "license": "MIT",
   "author": "William Swanson",
+  "type": "module",
   "exports": {
     ".": {
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./src/index.d.ts",
+        "default": "./lib/cleaners.js"
+      },
+      "require": {
+        "types": "./src/index.d.ts",
+        "default": "./lib/cleaners.cjs"
+      }
     },
     "./package.json": "./package.json"
   },
-  "main": "./lib/index.js",
+  "main": "./lib/cleaners.cjs",
   "module": "./lib/cleaners.js",
   "types": "./src/index.d.ts",
   "files": [
@@ -69,7 +76,6 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.26.7",
     "rollup-plugin-filesize": "^7.0.0",
-    "rollup-plugin-mjs-entry": "^0.1.0",
     "sucrase": "^3.15.0",
     "typescript": "^4.1.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import babel from '@rollup/plugin-babel'
 import filesize from 'rollup-plugin-filesize'
-import mjs from 'rollup-plugin-mjs-entry'
 
 import packageJson from './package.json'
 
@@ -17,5 +16,5 @@ export default {
     { file: packageJson.main, format: 'cjs' },
     { file: packageJson.module, format: 'es' }
   ],
-  plugins: [babel(babelOpts), filesize(sizeOpts), mjs()]
+  plugins: [babel(babelOpts), filesize(sizeOpts)]
 }

--- a/src/cleaners/asCodec.js
+++ b/src/cleaners/asCodec.js
@@ -1,18 +1,35 @@
-let uncleaning = 0
-
 export function asCodec(cleaner, uncleaner) {
   return function asCodec(raw) {
-    return uncleaning > 0 ? uncleaner(raw) : cleaner(raw)
+    return global[uncleaning] > 0 ? uncleaner(raw) : cleaner(raw)
   }
 }
 
 export function uncleaner(cleaner) {
   return function uncleaner(raw) {
+    // We need to set a flag to indicate that we are un-cleaning.
+    // The flag needs to be in a global location,
+    // since multiple cleaner implementations should agree
+    // which mode we are in.
+    if (global[uncleaning] == null) {
+      Object.defineProperty(global, uncleaning, {
+        value: 0,
+        writable: true
+      })
+    }
     try {
-      ++uncleaning
+      ++global[uncleaning]
       return cleaner(raw)
     } finally {
-      --uncleaning
+      --global[uncleaning]
     }
   }
 }
+
+// If we cannot find the standardized "globalThis" object,
+// fall back on using the "JSON" constructor, which is also well-known.
+const global =
+  typeof globalThis === 'object' && globalThis != null ? globalThis : JSON
+
+/* istanbul ignore next */
+const uncleaning =
+  typeof Symbol === 'function' ? Symbol.for('uncleaning') : 'uncleaning'

--- a/src/cleaners/asJSON.js
+++ b/src/cleaners/asJSON.js
@@ -1,6 +1,6 @@
-import { locateError } from '../locateError'
-import { asCodec } from './asCodec'
-import { asString } from './primitives'
+import { locateError } from '../locateError.js'
+import { asCodec } from './asCodec.js'
+import { asString } from './primitives.js'
 
 export function asJSON(cleaner) {
   return asCodec(

--- a/src/cleaners/asObject.js
+++ b/src/cleaners/asObject.js
@@ -1,4 +1,4 @@
-import { locateError } from '../locateError'
+import { locateError } from '../locateError.js'
 
 export function asObject(shape) {
   // The key-value version:

--- a/src/cleaners/asTuple.js
+++ b/src/cleaners/asTuple.js
@@ -1,4 +1,4 @@
-import { locateError } from '../locateError'
+import { locateError } from '../locateError.js'
 
 export function asTuple(...shape) {
   function asTuple(raw) {

--- a/test/cleaners/asCodec.test.ts
+++ b/test/cleaners/asCodec.test.ts
@@ -1,13 +1,38 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { asDate, asJSON, asObject, uncleaner } from '../../src/index.js'
+import {
+  asCodec,
+  asDate,
+  asJSON,
+  asObject,
+  asString,
+  uncleaner
+} from '../../src/index.js'
 
 describe('asCodec', function () {
-  const asFile = asJSON(asObject({ lastLogin: asDate }))
-  const wasFile = uncleaner(asFile)
+  it('can be called manually', function () {
+    const asHex = asCodec<number>(
+      raw => {
+        const clean = asString(raw)
+        if (!/^0x[0-9A-Fa-f]+$/.test(raw)) {
+          throw new Error('Expected a hex string')
+        }
+        return parseInt(clean.slice(2), 16)
+      },
+      clean => '0x' + clean.toString(16)
+    )
+    const wasHex = uncleaner(asHex)
+
+    expect(() => asHex(null)).throws('Expected a string')
+    expect(() => asHex('z')).throws('Expected a hex string')
+    expect(asHex('0x7f')).equals(127)
+    expect(wasHex(127)).equals('0x7f')
+  })
 
   it('round-trips data', function () {
+    const asFile = asJSON(asObject({ lastLogin: asDate }))
+    const wasFile = uncleaner(asFile)
     const raw = '{"lastLogin":"2020-02-20T00:00:00.000Z"}'
 
     const clean = asFile(raw)

--- a/test/cleaners/asTuple.test.ts
+++ b/test/cleaners/asTuple.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { asNumber, asString, asTuple } from '../../src/'
+import { asNumber, asString, asTuple } from '../../src/index.js'
 
 describe('asTuple', function () {
   const asNumberwang = asTuple(asNumber, asString)

--- a/test/flow.js
+++ b/test/flow.js
@@ -20,7 +20,7 @@ import {
   asUndefined,
   asUnknown,
   asValue
-} from '../src'
+} from '../src/index.js'
 
 const asUnixDate = asCodec(
   raw => new Date(1000 * asNumber(raw)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3432,11 +3432,6 @@ rollup-plugin-filesize@^7.0.0:
     lodash.merge "^4.6.2"
     terser "^4.1.3"
 
-rollup-plugin-mjs-entry@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-mjs-entry/-/rollup-plugin-mjs-entry-0.1.1.tgz#b3ab47e8d49ddb1916e36ba2480dc8a62a22d533"
-  integrity sha512-uii0Txyrn4YCgP++fypLqsT3LgO3Fx0gAZLZlWRSwKCuZ+bdSzAzdVbJFATmCHcBNlO61i65EgemOVdVQYONHA==
-
 rollup@^2.26.7:
   version "2.56.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.3.tgz#b63edadd9851b0d618a6d0e6af8201955a77aeff"


### PR DESCRIPTION
Running cleaners through a bundler like Webpack or recent Rollup versions will fail. This is because re-exporting CommonJS breaks expectations (they are looking for modules). Instead of putting a wrapper around our CommonJS entry point, just expose the raw module entry point.

This does create a problem, since multiple copies of the library won't agree on the cleaning / uncleaning mode. Fix that by moving the flag onto a global object instead.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204393537591071