### PR TITLE
Change the CommonJS extension back to js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
       },
       "require": {
         "types": "./src/index.d.ts",
-        "default": "./lib/cleaners.cjs"
+        "default": "./lib/cjs/cleaners.js"
       }
     },
     "./package.json": "./package.json"
   },
-  "main": "./lib/cleaners.cjs",
+  "main": "./lib/cjs/cleaners.js",
   "module": "./lib/cleaners.js",
   "types": "./src/index.d.ts",
   "files": [
@@ -38,7 +38,7 @@
     "clean": "rimraf lib",
     "fix": "eslint . --fix",
     "flow": "flow",
-    "lib": "rollup -c; cp src/index.js.flow lib",
+    "lib": "rollup -c && cp src/index.js.flow lib && echo '{\"type\":\"commonjs\"}' > lib/cjs/package.json",
     "lint": "eslint .",
     "precommit": "lint-staged && npm-run-all -p flow types",
     "prepare": "husky install && npm-run-all clean -p lib types",


### PR DESCRIPTION
The metro bundler is really unhappy with the "cjs" file extension. We can work around this by putting CommonJS in its own folder and putting a separate package.json in there to tell Node what the contents are.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204464302901537